### PR TITLE
removing system node language_version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
         files: \.(ts[x])$
         # https://github.com/pre-commit/pre-commit/issues/1064
         # https://github.com/ekalinin/nodeenv/issues/204
-        language_version: system
         additional_dependencies:
           - tslint
           - tslint-react
@@ -37,7 +36,6 @@ repos:
       - id: eslint
         # https://github.com/pre-commit/pre-commit/issues/1064
         # https://github.com/ekalinin/nodeenv/issues/204
-        language_version: system
         args: ["--ext=.js", .]
         additional_dependencies:
           - eslint@6.3.0


### PR DESCRIPTION
system not necessary anymore as I switched pre-commit image to use debian slim base which can correctly pull appropriate node version